### PR TITLE
Improve license normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to semantic-copycat-oslili will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.7] - 2025-08-29
+
+### Added
+- **Dynamic License Normalization**: Uses 1841+ name mappings from bundled SPDX data instead of hardcoding
+- **Properties for SPDX Data**: Added `aliases` and `name_mappings` properties to SPDXLicenseData class
+- **Comprehensive Normalization**: Support for 99.1% of SPDX licenses (694/700) with intelligent normalization
+- **Better Version Handling**: GPL/LGPL/AGPL versions properly normalized (e.g., GPL-3 → GPL-3.0)
+- **Common Aliases**: Added fallback aliases for "New BSD", "Simplified BSD", "CC0", etc.
+
+### Changed
+- **SPDX Tag Detection**: Improved regex to capture multi-word licenses like "Apache 2.0", "GPL v3"
+- **Normalization Method**: Refactored to use data-driven approach with bundled mappings
+- **Import Organization**: Moved module-level imports to avoid inline imports
+
+### Fixed
+- **Duplicate Methods**: Removed duplicate `_normalize_text()` and `get_all_license_ids()` methods in spdx_licenses.py
+- **Dead Code**: Removed unused methods and unreachable code sections
+- **Import Issues**: Fixed repeated inline imports of `re` module
+- **License Detection**: Fixed normalization for licenses with spaces (e.g., "Apache 2.0" → "Apache-2.0")
+- **Suffix Handling**: Proper handling of deprecated + suffix licenses (GPL-3.0+ → GPL-3.0-or-later)
+
+### Performance
+- **Code Quality**: Reduced duplication and improved maintainability
+- **Normalization Coverage**: Increased from ~12% to 99.1% for SPDX license ID variations
+
 ## [1.2.6] - 2025-08-17
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "semantic-copycat-oslili"
-version = "1.2.6"
+version = "1.2.7"
 description = "Semantic Copycat Open Source License Identification Library"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/semantic_copycat_oslili/__init__.py
+++ b/semantic_copycat_oslili/__init__.py
@@ -13,7 +13,7 @@ if os.environ.get('OSLILI_DEBUG') != '1':
     except ImportError:
         pass
 
-__version__ = "1.2.6"
+__version__ = "1.2.7"
 
 from .core.generator import LegalAttributionGenerator
 from .core.models import (

--- a/semantic_copycat_oslili/detectors/license_detector.py
+++ b/semantic_copycat_oslili/detectors/license_detector.py
@@ -63,7 +63,9 @@ class LicenseDetector:
         """Compile SPDX identifier patterns."""
         return [
             # SPDX-License-Identifier: <license>
-            re.compile(r'SPDX-License-Identifier:\s*([^\s\n]+)', re.IGNORECASE),
+            # Match until end of line, comment marker, or semicolon
+            # Strip trailing comment markers and whitespace
+            re.compile(r'SPDX-License-Identifier:\s*([^\n;#*]+?)(?:\s*[*/]*\s*)?$', re.IGNORECASE | re.MULTILINE),
             # Python METADATA: License-Expression: <license>
             re.compile(r'License-Expression:\s*([^\s\n]+)', re.IGNORECASE),
             # package.json style: "license": "MIT"
@@ -611,7 +613,6 @@ class LicenseDetector:
     
     def _extract_version(self, text: str) -> Optional[str]:
         """Extract version number from license text."""
-        import re
         # Match patterns like 2.0, 3, 3.0, etc.
         match = re.search(r'(\d+(?:\.\d+)?)', text)
         if match:
@@ -625,7 +626,6 @@ class LicenseDetector:
             return 'CC0-1.0'
         
         # Extract CC components
-        import re
         
         # Common CC license pattern: CC-BY-SA-4.0
         cc_match = re.search(r'CC[- ]?(BY|ZERO)?[- ]?(SA|NC|ND)?[- ]?(\d+\.\d+)?', license_text.upper())
@@ -919,7 +919,6 @@ class LicenseDetector:
                 return True
         
         # Check if it matches common license ID format (e.g., Apache-2.0, GPL-3.0+)
-        import re
         if re.match(r'^[A-Za-z]+[\-\.]?[0-9]*\.?[0-9]*[\+]?$', license_id):
             return True
         


### PR DESCRIPTION
  Summary of changes in v1.2.7:

  License Normalization Improvements:
  - Achieved 99.1% coverage (694/700 SPDX licenses) vs previous ~12%
  - Dynamic approach using 1841+ name mappings from bundled data
  - Fixed SPDX tag detection for multi-word licenses ("Apache 2.0", "GPL v3")
  - Proper version handling (GPL-3 → GPL-3.0)

  Code Quality Improvements:
  - Removed duplicate _normalize_text() methods in spdx_licenses.py
  - Removed duplicate get_all_license_ids() methods
  - Fixed inline import re statements (moved to module level)
  - Eliminated dead code and improved maintainability

  Version Updates:
  - Bumped to v1.2.7 in pyproject.toml and init.py
  - Updated CHANGELOG with all improvements