### PR TITLE
Fix license detection issues and improve accuracy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to semantic-copycat-oslili will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.8] - 2025-08-29
+
+### Fixed
+- **License Expression Parsing**: Fixed incorrect splitting of "or later" suffix (e.g., "LGPL 3 or later" now correctly parsed as single license)
+- **False Positive Detection**: Added filtering for TODO, FIXME, XXX, and placeholder text that were incorrectly detected as licenses
+- **MIT License Detection**: Added quick pattern matching for MIT licenses before TLSH to prevent misidentification as JSON
+- **Test File Scanning**: Fixed overly aggressive filtering that skipped all files with "test_" prefix, now only skips specific test patterns
+
+### Improved
+- **Detection Accuracy**: Significantly reduced false positives in license identification
+- **Expression Handling**: Better handling of license suffixes like "or later", "or-later", "+"
+
 ## [1.2.7] - 2025-08-29
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "semantic-copycat-oslili"
-version = "1.2.7"
+version = "1.2.8"
 description = "Semantic Copycat Open Source License Identification Library"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/semantic_copycat_oslili/__init__.py
+++ b/semantic_copycat_oslili/__init__.py
@@ -13,7 +13,7 @@ if os.environ.get('OSLILI_DEBUG') != '1':
     except ImportError:
         pass
 
-__version__ = "1.2.7"
+__version__ = "1.2.8"
 
 from .core.generator import LegalAttributionGenerator
 from .core.models import (


### PR DESCRIPTION
## Summary
- Fixed parsing of "or later" license suffixes
- Added false positive filtering for common placeholders
- Improved MIT license detection accuracy

## Changes

### License Expression Parsing
- Modified `_parse_license_expression()` to correctly handle "or later" suffixes
- Prevents incorrect splitting of licenses like "LGPL 3 or later" into separate tokens

### False Positive Prevention
- Added filtering for TODO, FIXME, XXX, and other placeholder text
- These were previously being detected as potential licenses with high confidence scores

### MIT License Detection
- Added quick pattern matching for MIT licenses before TLSH matching
- Prevents MIT LICENSE files from being incorrectly identified as JSON licenses

### Test File Handling
- Fixed overly aggressive test file filtering
- Now only skips specific test patterns instead of all files with "test_" prefix

## Test Results
All three issues identified during testing have been resolved:
1. ✅ "LGPL 3 or later" correctly parsed as single license
2. ✅ TODO/FIXME no longer detected as licenses
3. ✅ MIT LICENSE files correctly identified as MIT

## Impact
These fixes significantly improve detection accuracy and reduce false positives in license identification, particularly for projects using common license suffixes and containing development placeholders.